### PR TITLE
hikes ecmaVersion for node

### DIFF
--- a/configurations/node.js
+++ b/configurations/node.js
@@ -7,6 +7,11 @@ module.exports = {
 		node: true
 	},
 
+	// https://eslint.org/docs/user-guide/configuring#specifying-parser-options
+	parserOptions: {
+		ecmaVersion: 8
+	},
+
 	// Plugins
 	plugins: [
 		'node'


### PR DESCRIPTION
specifies `ecmaVersion: 8` for `node`, as the linter complained for using `async` functions, which are an ES2017/ES8 feature IIRC.

I am not expert on these eslint configs so hopefully someone who is can have a look :)