### PR TITLE
Bump up versions of all ESlint dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,21 +20,21 @@
     "static analysis"
   ],
   "devDependencies": {
-    "eslint": "^4.18.0",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jest": "^21.13.0",
+    "eslint": "^5.1.0",
+    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-jest": "^21.17.0",
     "eslint-plugin-no-use-extend-native": "^0.3.12",
     "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-unicorn": "^4.0.2"
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-unicorn": "^4.0.3"
   },
   "peerDependencies": {
-    "eslint": "^4.18.0",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jest": "^21.13.0",
+    "eslint": "^5.1.0",
+    "eslint-plugin-import": "^2.13.0",
+    "eslint-plugin-jest": "^21.17.0",
     "eslint-plugin-no-use-extend-native": "^0.3.12",
     "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.6.0",
-    "eslint-plugin-unicorn": "^4.0.2"
+    "eslint-plugin-promise": "^3.8.0",
+    "eslint-plugin-unicorn": "^4.0.3"
   }
 }


### PR DESCRIPTION
Making sure ESlint is fully up to date
https://eslint.org/blog/2018/07/postmortem-for-malicious-package-publishes

Migration guidelines:
https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-5.0.0.md