### PR TITLE
Fix bug in no-unused-vars

### DIFF
--- a/configurations/core.js
+++ b/configurations/core.js
@@ -158,7 +158,7 @@ module.exports = {
 		'no-unused-expressions': 'error',
 		'no-unused-vars': ['error', {
 			'ignoreRestSiblings': true,
-			'argsIgnorePattern': '^_$'
+			'argsIgnorePattern': '^_'
 		}],
 		'no-use-before-define': ['error', 'nofunc'],
 		'no-useless-call': 'error',

--- a/configurations/legacy.js
+++ b/configurations/legacy.js
@@ -151,7 +151,7 @@ module.exports = {
 		'no-unused-expressions': 'error',
 		'no-unused-vars': ['error', {
 			'ignoreRestSiblings': true,
-			'argsIgnorePattern': '^_$'
+			'argsIgnorePattern': '^_'
 		}],
 		'no-use-before-define': ['error', 'nofunc'],
 		'no-useless-call': 'error',


### PR DESCRIPTION
This fixes a bug in the `no-unused-vars` rule when specifying an `argsIgnorePattern`.  The aim of the pattern is allow unused vars if they start with an underscore, as per the example in [the documentation](https://eslint.org/docs/rules/no-unused-vars#argsignorepattern) - `"argsIgnorePattern": "^_"`.

Our rule specified `"argsIgnorePattern": "^_$"` which means that only arguments called `_` can be unused, rather than `_name-of-arg`.