### PR TITLE
Update dependencies to latest version

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,31 +1,47 @@
 # History
 
+## 3.0.0 (2019-09-06)
+
+* [`[Breaking]`](https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-6.0.0.md) Update ESLint to version 6, which drops support for Node 6. Fixes a vulnerability present in eslint <6.2.1
+* [`[Breaking]`](https://github.com/jest-community/eslint-plugin-jest/releases/tag/v22.0.0) Update `eslint-plugin-jest` from v21 to v22
+* [`[Breaking]`](https://github.com/mysticatea/eslint-plugin-node/releases) Update `eslint-plugin-node` from v6 to v10
+* [`[Breaking]`](https://github.com/xjamundx/eslint-plugin-promise/blob/master/CHANGELOG.md#400) Update `eslint-plugin-promise` from v3 to v4
+* [`[Breaking]`](https://github.com/sindresorhus/eslint-plugin-unicorn/releases) Update `eslint-plugin-unicorn` from v4 to v10
+* Update `eslint-plugin-import`
+* Update `eslint-plugin-no-use-extend-native`
+* Add [additional example files](./examples)
+* Run markdown docs through `markdownlint` for some sweet extra linting
+
 ## 2.1.1 (2019-08-29)
-	* Fix `no-unused-vars > argsIgnorePattern` to ignore underscored variable names
+
+* Fix `no-unused-vars > argsIgnorePattern` to ignore underscored variable names
 
 ## 2.1.0 (2019-05-15)
-	* Remove `import/prefer-default-export` rule
+
+* Remove `import/prefer-default-export` rule
 
 ## 2.0.0 (2018-07-17)
-	* Update ESLint to version 5
-	  - https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-5.0.0.md
-	* Update to new version of `eslint-plugin-import`
-	* Update to new version of `eslint-plugin-jest`
-	* Update to new version of `eslint-plugin-promise`
-	* Update to new version of `eslint-plugin-unicorn`
+
+* Update ESLint to version 5 ([Migration guide](https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-5.0.0.md))
+* Update to new version of `eslint-plugin-import`
+* Update to new version of `eslint-plugin-jest`
+* Update to new version of `eslint-plugin-promise`
+* Update to new version of `eslint-plugin-unicorn`
 
 ## 1.0.0 (2018-03-06)
-	* Move `eslint-plugin-node` to an optional add on
-	* Add a legacy option for projects without ES6
-	* Add `eslint-plugin-jest` as an optional add on
-	* Improve documentation
+
+* Move `eslint-plugin-node` to an optional add on
+* Add a legacy option for projects without ES6
+* Add `eslint-plugin-jest` as an optional add on
+* Improve documentation
 
 ## 0.1.0 (2018-03-05)
-    * Common linting rules
-	* Extends `eslint:recommended`
-	* Includes plugins
-	  - `eslint-plugin-import`
-	  - `eslint-plugin-no-use-extend-native`
-	  - `eslint-plugin-node`
-	  - `eslint-plugin-promise`
-	  - `eslint-plugin-unicorn`
+
+* Common linting rules
+* Extends `eslint:recommended`
+* Includes plugins
+  * `eslint-plugin-import`
+  * `eslint-plugin-no-use-extend-native`
+  * `eslint-plugin-node`
+  * `eslint-plugin-promise`
+  * `eslint-plugin-unicorn`

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ ESLint shareable config used at [Springer Nature](https://www.springernature.com
 
 This package requires:
 
-* Node version 6 or greater. Please have a look at our [open source support page](https://github.com/springernature/frontend-playbook/blob/master/practices/open-source-support.md#node-versions) for details on which versions of node we support, and why.
-* `eslint` version 5 or greater.
+* Node version 8 or greater. Please have a look at our [open source support page](https://github.com/springernature/frontend-playbook/blob/master/practices/open-source-support.md#node-versions) for details on which versions of node we support, and why.
+* `eslint` version 6 or greater.
 
 ## Installation
 

--- a/examples/core-.eslintrc
+++ b/examples/core-.eslintrc
@@ -1,0 +1,9 @@
+{
+	"extends": "@springernature/eslint-config",
+	"rules": {
+		// Additional, per-project rules...
+	},
+	"overrides": [
+		// Overrides for specific files or directories
+	]
+}

--- a/examples/extensions-.eslintrc
+++ b/examples/extensions-.eslintrc
@@ -1,0 +1,13 @@
+{
+	"extends": [
+		"@springernature/eslint-config",
+		"@springernature/eslint-config/node",
+		"@springernature/eslint-config/jest"
+	],
+	"rules": {
+		// Additional, per-project rules...
+	},
+	"overrides": [
+		// Overrides for specific files or directories
+	]
+}

--- a/examples/legacy-.eslintrc
+++ b/examples/legacy-.eslintrc
@@ -1,0 +1,9 @@
+{
+	"extends": "@springernature/eslint-config/legacy",
+	"rules": {
+		// Additional, per-project rules...
+	},
+	"overrides": [
+		// Overrides for specific files or directories
+	]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/eslint-config",
-  "version": "2.1.1",
+  "version": "3.0.0",
   "description": "ESLint shareable config used at Springer Nature",
   "license": "",
   "repository": "springernature/eslint-config-springernature",
@@ -8,11 +8,12 @@
   "bugs": "https://github.com/springernature/eslint-config-springernature/issues",
   "author": "Springer Nature",
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "keywords": [
     "springer nature",
     "eslint",
+    "eslint config",
     "eslintconfig",
     "lint",
     "linter",
@@ -20,21 +21,21 @@
     "static analysis"
   ],
   "devDependencies": {
-    "eslint": "^5.1.0",
-    "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-jest": "^21.17.0",
-    "eslint-plugin-no-use-extend-native": "^0.3.12",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.8.0",
-    "eslint-plugin-unicorn": "^4.0.3"
+    "eslint": "^6.3.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jest": "^22.17.0",
+    "eslint-plugin-no-use-extend-native": "^0.4.1",
+    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-unicorn": "^10.0.0"
   },
   "peerDependencies": {
-    "eslint": "^5.1.0",
-    "eslint-plugin-import": "^2.13.0",
-    "eslint-plugin-jest": "^21.17.0",
-    "eslint-plugin-no-use-extend-native": "^0.3.12",
-    "eslint-plugin-node": "^6.0.1",
-    "eslint-plugin-promise": "^3.8.0",
-    "eslint-plugin-unicorn": "^4.0.3"
+    "eslint": "^6.3.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jest": "^22.17.0",
+    "eslint-plugin-no-use-extend-native": "^0.4.1",
+    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-unicorn": "^10.0.0"
   }
 }


### PR DESCRIPTION
* [`[Breaking]`](https://github.com/eslint/eslint/blob/master/docs/user-guide/migrating-to-6.0.0.md) Update ESLint to version 6, which drops support for Node 6. Fixes a vulnerability present in eslint <6.2.1
* [`[Breaking]`](https://github.com/jest-community/eslint-plugin-jest/releases/tag/v22.0.0) Update `eslint-plugin-jest` from v21 to v22
* [`[Breaking]`](https://github.com/mysticatea/eslint-plugin-node/releases) Update `eslint-plugin-node` from v6 to v10
* [`[Breaking]`](https://github.com/xjamundx/eslint-plugin-promise/blob/master/CHANGELOG.md#400) Update `eslint-plugin-promise` from v3 to v4
* [`[Breaking]`](https://github.com/sindresorhus/eslint-plugin-unicorn/releases) Update `eslint-plugin-unicorn` from v4 to v10
* Update `eslint-plugin-import`
* Update `eslint-plugin-no-use-extend-native`
* Add [additional example files](./examples)
* Run markdown docs through `markdownlint` for some sweet extra linting