### PR TITLE
Disables prefer-dataset unicorn rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.idea/

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## 4.0.2 (2020-09-30)
 
-* Switch off `unicorn/prefer-dataset` rule as not Element.dataset not supported by ie10
+* Disables `unicorn/prefer-dataset` rule as Element.dataset not supported by ie10
 
 
 ## 4.0.1 (2020-02-18)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,10 @@
 # History
 
+## 4.0.2 (2020-09-30)
+
+* Switch off `unicorn/prefer-dataset` rule as not Element.dataset not supported by ie10
+
+
 ## 4.0.1 (2020-02-18)
 
 * Switch off `unicorn/prefer-node-append` rule for IE support

--- a/configurations/core.js
+++ b/configurations/core.js
@@ -275,6 +275,7 @@ module.exports = {
 		// https://github.com/sindresorhus/eslint-plugin-unicorn
 		'unicorn/prefer-spread': 'off',
 		'unicorn/no-new-buffer': 'off',
+		'unicorn/prefer-dataset': 'off',
 		'unicorn/prefer-node-append': 'off'
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/eslint-config",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "ESLint shareable config used at Springer Nature",
   "license": "",
   "repository": "springernature/eslint-config-springernature",


### PR DESCRIPTION
Disables `unicorn/prefer-dataset` rule as Element.dataset not supported by ie10 (ie10 cuts the mustard on our websites)