### PR TITLE
Disables no-return-await rule in core

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@
 
 ## 4.0.3 (2021-02-12)
 
-* Disables `no-return-await` rule as v8 changes render `return await` useful
+* Disables `no-return-await` rule in core as v8 changes render `return await` useful
 
 ## 4.0.2 (2020-09-30)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,9 +1,12 @@
 # History
 
+## 4.0.3 (2021-02-12)
+
+* Disables `no-return-await` rule as v8 changes render `return await` useful
+
 ## 4.0.2 (2020-09-30)
 
 * Disables `unicorn/prefer-dataset` rule as Element.dataset not supported by ie10
-
 
 ## 4.0.1 (2020-02-18)
 

--- a/configurations/core.js
+++ b/configurations/core.js
@@ -138,7 +138,7 @@ module.exports = {
 		'no-restricted-modules': ['error', 'domain', 'freelist', 'smalloc', 'sys', 'colors'],
 		'no-restricted-syntax': ['error', 'WithStatement'],
 		'no-return-assign': ['error', 'always'],
-		'no-return-await': 'error',
+		'no-return-await': 'off',
 		'no-script-url': 'error',
 		'no-self-assign': ['error', {
 			'props': true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/eslint-config",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "ESLint shareable config used at Springer Nature",
   "license": "",
   "repository": "springernature/eslint-config-springernature",


### PR DESCRIPTION
As per [this SO post](https://stackoverflow.com/questions/44806135/why-no-return-await-vs-const-x-await?answertab=active#tab-top) and [this v8 post](https://v8.dev/blog/fast-async#improved-developer-experience) `return await` can now be useful as it gives a better stack trace.
