### PR TITLE
Switch off unicorn/prefer-dom-node-remove | Rename deprecated rules

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@
 ## 5.0.1 (2021-09-15)
 
 * Switch off `unicorn/prefer-dom-node-remove` rule for IE support
+* Rename `unicorn/prefer-node-remove` to `unicorn/prefer-dom-node-dataset` following deprecation
+* Rename `unicorn/prefer-dataset` to `unicorn/prefer-dom-node-dataset` following deprecation
 
 ## 5.0.0 (2021-02-15)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 5.0.1 (2021-09-15)
+
+* Switch off `unicorn/prefer-dom-node-remove` rule for IE support
+
 ## 5.0.0 (2021-02-15)
 
 * Updates all dependencies, the following updates are **breaking**:

--- a/configurations/core.js
+++ b/configurations/core.js
@@ -276,6 +276,7 @@ module.exports = {
 		'unicorn/prefer-spread': 'off',
 		'unicorn/no-new-buffer': 'off',
 		'unicorn/prefer-dataset': 'off',
-		'unicorn/prefer-node-append': 'off'
+		'unicorn/prefer-node-append': 'off',
+		'unicorn/prefer-dom-node-remove': 'off'
 	}
 };

--- a/configurations/core.js
+++ b/configurations/core.js
@@ -275,8 +275,8 @@ module.exports = {
 		// https://github.com/sindresorhus/eslint-plugin-unicorn
 		'unicorn/prefer-spread': 'off',
 		'unicorn/no-new-buffer': 'off',
-		'unicorn/prefer-dataset': 'off',
-		'unicorn/prefer-node-append': 'off',
+		'unicorn/prefer-dom-node-dataset': 'off',
+		'unicorn/prefer-dom-node-append': 'off',
 		'unicorn/prefer-dom-node-remove': 'off'
 	}
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/eslint-config",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "ESLint shareable config used at Springer Nature",
   "license": "MIT",
   "repository": "springernature/eslint-config-springernature",


### PR DESCRIPTION
`.remove()` method is not supported by IE.