### PR TITLE
Version 6.0.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,7 @@
 * Bump dependencies so that ESLint v8.* can be used in projects that also use @springernature/eslint-config
 * In fact at least ESLint v8.38.0 is needed due to breaking changes in `eslint-plugin-unicorn` v47.0.0
 * Requires at least Node v16, but since security support for v16 is running out on 11 Sep 2023, we say that we reqiure at least v18
-* The upgrade from `eslint-plugin-unicorn` v28 to v47 brought mostly bugfixes and new features. The only breaking change affecting this repo was the chnage of the `prevent-abbreviations` rule's setting `whitelist` to `allowlist` in v30.0.0.
+* The upgrade from `eslint-plugin-unicorn` v28 to v47 brought mostly bugfixes and new features. The only breaking change affecting this repo was the change of the `prevent-abbreviations` rule setting `whitelist` to `allowlist` in v30.0.0.
 
 ## 5.0.5 (2021-11-12)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,8 +4,21 @@
 
 * Bump dependencies so that ESLint v8.* can be used in projects that also use @springernature/eslint-config
 * In fact at least ESLint v8.38.0 is needed due to breaking changes in `eslint-plugin-unicorn` v47.0.0
-* Requires at least Node v16, but since security support for v16 is running out on 11 Sep 2023, we say that we reqiure at least v18
+* Requires technically at least Node v16, but since security support for v16 is running out on 11 Sep 2023, we say that we reqiure at least v18
 * The upgrade from `eslint-plugin-unicorn` v28 to v47 brought mostly bugfixes and new features. The only breaking change affecting this repo was the change of the `prevent-abbreviations` rule setting `whitelist` to `allowlist` in v30.0.0.
+
+### Hint
+
+A major change in the output of ESLint after updating this module to version 6.0.0 will be the recommended switch from CommonJS modules to using ES6 modules due to the new settings in `unicorn`. This change can be a major effort and if you do not want to make this switch due to the update of the `@springernature/eslint-config` module, you can disable this rule in the rules section of your project's ESLint configuration:
+
+```json
+  [...]
+  "rules": {
+    [...]
+    "unicorn/prefer-module": 0
+  },
+
+```
 
 ## 5.0.5 (2021-11-12)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## 6.0.0 (2023-06-21)
+
+* Bump dependencies so that ESLint v8.* can be used in projects that also use @springernature/eslint-config
+* In fact at least ESLint v8.38.0 is needed due to breaking changes in `eslint-plugin-unicorn` v47.0.0
+* Requires at least Node v16, but since security support for v16 is running out on 11 Sep 2023, we say that we reqiure at least v18
+* The upgrade from `eslint-plugin-unicorn` v28 to v47 brought mostly bugfixes and new features. The only breaking change affecting this repo was the chnage of the `prevent-abbreviations` rule's setting `whitelist` to `allowlist` in v30.0.0.
+
 ## 5.0.5 (2021-11-12)
 
 * Attempts again to revert versions of npm dependencies back to same as 5.0.1.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ESLint shareable config used at [Springer Nature](https://www.springernature.com
 
 This package requires:
 
-* [Node version 18 or greater](https://nodejs.org/en/download/releases) due to support for v16 running out soon this year. Please have a look at our [open source support page](https://github.com/springernature/frontend-playbook/blob/master/practices/open-source-support.md#node-versions) for details on which versions of node we support, and why.
+* [Node version 18 or greater](https://nodejs.org/en/download/releases) due to support for v16 running out soon this year. Please have a look at our [open source support page](https://github.com/springernature/frontend-playbook/blob/master/practices/open-source-support.md#node-versions) for details on which versions of node we support, and why. Version 5 of this package supports Node versions >=8 and <16.
 * `eslint` version 8.38.0 or greater (due to eslint-plugin-unicorn v47.0.0).
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ ESLint shareable config used at [Springer Nature](https://www.springernature.com
 
 This package requires:
 
-* Node version 8 or greater. Please have a look at our [open source support page](https://github.com/springernature/frontend-playbook/blob/master/practices/open-source-support.md#node-versions) for details on which versions of node we support, and why.
-* `eslint` version 6 or greater.
+* [Node version 18 or greater](https://nodejs.org/en/download/releases) due to support for v16 running out soon this year. Please have a look at our [open source support page](https://github.com/springernature/frontend-playbook/blob/master/practices/open-source-support.md#node-versions) for details on which versions of node we support, and why.
+* `eslint` version 8.38.0 or greater (due to eslint-plugin-unicorn v47.0.0).
 
 ## Installation
 

--- a/configurations/node.js
+++ b/configurations/node.js
@@ -31,7 +31,7 @@ module.exports = {
 		'unicorn/prevent-abbreviations': [
 			'error',
 			{
-				'whitelist': {
+				'allowList': {
 					'err': true,
 					'req': true,
 					'res': true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/eslint-config",
-  "version": "5.0.5",
+  "version": "6.0.0",
   "description": "ESLint shareable config used at Springer Nature",
   "license": "MIT",
   "repository": "springernature/eslint-config-springernature",
@@ -8,7 +8,7 @@
   "bugs": "https://github.com/springernature/eslint-config-springernature/issues",
   "author": "Springer Nature",
   "engines": {
-    "node": ">=8"
+    "node": ">=18"
   },
   "keywords": [
     "springer nature",
@@ -21,21 +21,21 @@
     "static analysis"
   ],
   "devDependencies": {
-    "eslint": "^7.17.0",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^24.1.3",
+    "eslint": "^8.43.0",
+    "eslint-plugin-import": "^2.27.5",
+    "eslint-plugin-jest": "^27.2.2",
     "eslint-plugin-no-use-extend-native": "^0.5.0",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.3.1",
-    "eslint-plugin-unicorn": "^28.0.1"
+    "eslint-plugin-promise": "^6.1.1",
+    "eslint-plugin-unicorn": "^47.0.0"
   },
   "peerDependencies": {
-    "eslint": "^7.17.0",
-    "eslint-plugin-import": "^2.22.1",
-    "eslint-plugin-jest": "^24.1.3",
+    "eslint": "^8.38.x",
+    "eslint-plugin-import": "^2.27.x",
+    "eslint-plugin-jest": "^27.x",
     "eslint-plugin-no-use-extend-native": "^0.5.0",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^4.3.1",
-    "eslint-plugin-unicorn": "^28.0.1"
+    "eslint-plugin-node": "^11.x",
+    "eslint-plugin-promise": "^6.x",
+    "eslint-plugin-unicorn": "^47.x"
   }
 }


### PR DESCRIPTION
This update was made so eslint-config-springernature can be used with ESLint v8.38.x and higher.

I updated the following dependencies:

- `eslint` from ^7.17.0 to ^8.43.0
- `eslint-plugin-import` from ^2.22.1 to ^2.27.5
- `eslint-plugin-jest` from ^24.1.3 to ^27.2.2
- `eslint-plugin-promise` from ^4.3.1 to ^6.1.1
- `eslint-plugin-unicorn` from ^28.0.1 to ^47.0.0

Also, these version updates require at least NodeJS v18, which is reflected in the `package.json` file.

The only change or the original ESLint rules that had to be made due to changes in the Unicorn plugin was renaming the `whitelist` option to `allowlist`.

All other changes are related to discontinuing support for older Node.js versions and older ESLint versions, as well as some changes that I consider exotic.

The README and the HISTORY files have been updated accordingly.