### PR TITLE
Allow require for node apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ These _optional_ extensions can be added in **addition** to one of the above con
 }
 ```
 
+```js
+// Core config extended with node extension for subset of files
+// Useful if you both node and browser js in the same repo
+{
+	"extends": "@springernature/eslint-config",
+	"overrides": [
+		{
+			"files": [
+				"path/to/app/files/*.js"
+			],
+			"extends": "@springernature/eslint-config/node"
+		}
+	]
+}
+```
+
 ### Ignore files/folders
 
 You can optionally create an `.eslintignore` file to ignore file paths. The `.eslintignore` file is a plain text file where each line is a glob pattern indicating which paths should be omitted from linting. For example, the following will ignore all files in the `tests` and `coverage` folders:

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ These _optional_ extensions can be added in **addition** to one of the above con
 ```
 
 ```js
-// Core config extended with node extension for subset of files
-// Useful if you both node and browser js in the same repo
+// Core config extended with node config for subset of files
+// Useful if you use both node and browser js in the same repo
 {
 	"extends": "@springernature/eslint-config",
 	"overrides": [

--- a/configurations/node.js
+++ b/configurations/node.js
@@ -20,6 +20,8 @@ module.exports = {
 		'node/no-unpublished-bin': 'error',
 		'node/process-exit-as-throw': 'error',
 		'node/no-deprecated-api': 'error',
+		// unicorn overrides
+		"unicorn/prefer-module": 0,
 		'unicorn/catch-error-name': [
 			'error',
 			{

--- a/examples/app-.eslintrc
+++ b/examples/app-.eslintrc
@@ -1,0 +1,11 @@
+{
+	"extends": "@springernature/eslint-config",
+	"overrides": [
+		{
+			"files": [
+				"path/to/app/files/*.js"
+			],
+			"extends": "@springernature/eslint-config/node"
+		}
+	]
+}


### PR DESCRIPTION
At some point the `unicorn` plugin added a rule preferring JavaScript modules (ESM) over CommonJS. This rule breaks most of our node apps that use Express.

The simplest solution is to remove this rule for the node configuration to maintain compatibility.