### PR TITLE
Version 6.1.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # History
 
+## 6.1.0 (2024-04-23)
+
+* v6.0.0 pushes ESM Modules, but for `node` environments we still want to support commonJS
+  * Remove `unicorn/prefer-module` rule for the `node` config
+  * For node environments, requires use of "global form of 'use strict'" i.e. requires `'use strict';` at top of file.
+
 ## 6.0.0 (2023-06-21)
 
 * Bump dependencies so that ESLint v8.* can be used in projects that also use @springernature/eslint-config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@springernature/eslint-config",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "ESLint shareable config used at Springer Nature",
   "license": "MIT",
   "repository": "springernature/eslint-config-springernature",


### PR DESCRIPTION
* Ensure CommonJS syntax is still supported by default for Node environments
* Require `use strict;` declarations for node js files
* If using ESM modules then both of these can be changed on a per-project basis